### PR TITLE
OPER-1992 Fix key management

### DIFF
--- a/lib/tapjoy/ldap/base.rb
+++ b/lib/tapjoy/ldap/base.rb
@@ -45,7 +45,7 @@ module Tapjoy
       end
 
       def add_attribute(distinguished_name, attribute, value)
-        @conn.add_attribute(dn, attribute, value)
+        @conn.add_attribute(distinguished_name, attribute, value)
         return return_result
       end
 

--- a/lib/tapjoy/ldap/key/show.rb
+++ b/lib/tapjoy/ldap/key/show.rb
@@ -6,7 +6,7 @@ module Tapjoy
         def show
           username = opts[:user]
           keys = Tapjoy::LDAP::Key.get_keys_from_ldap[username]
-          puts "No keys found for #{opts[:user]}" if keys.length? 0
+          puts "No keys found for #{opts[:user]}" if keys.nil?
           puts keys
         end
 

--- a/lib/tapjoy/ldap/version.rb
+++ b/lib/tapjoy/ldap/version.rb
@@ -3,7 +3,7 @@ module Tapjoy
     module Version
       MAJOR = 0
       MINOR = 7
-      PATCH = 1
+      PATCH = 2
     end
 
     VERSION = [Version::MAJOR, Version::MINOR, Version::PATCH].join('.')


### PR DESCRIPTION
1. Add key method was broken due to method input mismatch
1. Empty keys return `nil` on lookup, rather than a string.
  - also, `length?` is not a string method :)
1. Version bamp

@Tapjoy/eng-group-ops