### PR TITLE
Allow ldaptools to use env vars as well as config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .yardoc/
 doc/
 Gemfile.lock
+coverage/*

--- a/bin/ldaptools
+++ b/bin/ldaptools
@@ -2,5 +2,3 @@
 require 'tapjoy/ldap'
 
 Tapjoy::LDAP::CLI.commands
-# Tapjoy::LDAP::API::User.create('ali', 'tayarani', 'user', 'users')
-# Tapjoy::LDAP::API::User.destroy('ali.tayarani', 'user')

--- a/ldap_tools.gemspec
+++ b/ldap_tools.gemspec
@@ -25,4 +25,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('guard-yard', '~> 2.1')
   s.add_development_dependency('guard-yardstick', '~> 0.1')
   s.add_development_dependency('codacy-coverage', '~>1.0')
+  s.add_development_dependency 'pry'
+  s.add_development_dependency 'pry-byebug'
 end

--- a/lib/tapjoy/ldap.rb
+++ b/lib/tapjoy/ldap.rb
@@ -2,11 +2,13 @@ require 'net/ldap'
 require 'yaml'
 require 'trollop'
 require 'memoist'
+require 'pry'
 require_relative 'ldap/cli'
 require_relative 'ldap/base'
 require_relative 'ldap/key'
 require_relative 'ldap/audit'
 require_relative 'ldap/version'
+require_relative 'ldap/errors'
 
 
 module Tapjoy

--- a/lib/tapjoy/ldap/errors.rb
+++ b/lib/tapjoy/ldap/errors.rb
@@ -1,0 +1,12 @@
+module Tapjoy
+  module LDAP
+    module Errors
+      # Raise if error LDAP_SERVERS is incorrect
+      class UndefinedServers < NoMethodError
+        def initialize
+          abort("FATAL: LDAP_SERVERS is undefined.")
+        end
+      end
+    end
+  end
+end

--- a/lib/tapjoy/ldap/version.rb
+++ b/lib/tapjoy/ldap/version.rb
@@ -2,7 +2,7 @@ module Tapjoy
   module LDAP
     module Version
       MAJOR = 0
-      MINOR = 8
+      MINOR = 9
       PATCH = 2
     end
 

--- a/spec/tapjoy/ldap.rb
+++ b/spec/tapjoy/ldap.rb
@@ -4,6 +4,7 @@ RSpec.shared_context 'ldap' do
   before(:each) do
     allow(Tapjoy::LDAP).to receive(:client).and_return(fake_ldap)
     allow(fake_ldap).to receive(:basedn).and_return('dc=example,dc=net')
+    allow(ENV).to receive(:[]).with("LDAP_SERVERS").and_return(fake_ldap)
     ARGV.clear
   end
 end


### PR DESCRIPTION
@Tapjoy/eng-group-ops 

Notes:
This will make supporting containerized environments much easier.