### PR TITLE
Remove unused activesupport dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [0.10.1](https://github.com/Tapjoy/ldap_tools/tree/0.10.1) (2017-12-20)
+[Full Changelog](https://github.com/Tapjoy/ldap_tools/compare/0.10.0...0.10.1)
+
 ## [0.10.0](https://github.com/Tapjoy/ldap_tools/tree/0.10.0) (2017-10-13)
 [Full Changelog](https://github.com/Tapjoy/ldap_tools/compare/0.9.2...0.10.0)
 
@@ -12,6 +15,7 @@
 
 **Merged pull requests:**
 
+- update changelog [\#20](https://github.com/Tapjoy/ldap_tools/pull/20) ([atayarani](https://github.com/atayarani))
 - Allow ldaptools to use env vars as well as config files [\#19](https://github.com/Tapjoy/ldap_tools/pull/19) ([atayarani](https://github.com/atayarani))
 
 ## [0.8.2](https://github.com/Tapjoy/ldap_tools/tree/0.8.2) (2016-07-13)

--- a/ldap_tools.gemspec
+++ b/ldap_tools.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('net-ldap', '= 0.11')
   s.add_runtime_dependency('highline', '~> 1.0')
   s.add_runtime_dependency('memoist', '>= 0.14')
-  s.add_runtime_dependency('activesupport', '~> 4.2')
   s.add_development_dependency('rspec', '~> 3.2')
   s.add_development_dependency('yard', '~> 0.8')
   s.add_development_dependency('guard', '~> 2.13')

--- a/lib/tapjoy/ldap/version.rb
+++ b/lib/tapjoy/ldap/version.rb
@@ -3,7 +3,7 @@ module Tapjoy
     module Version
       MAJOR = 0
       MINOR = 10
-      PATCH = 0
+      PATCH = 1
     end
 
     VERSION = [Version::MAJOR, Version::MINOR, Version::PATCH].join('.')


### PR DESCRIPTION
@ehealy 
/cc @Tapjoy/eng-group-ops 

Notes:
* Originally, we included activesupport for `#titleize`, however it appears we replaced it with `#capitalize` which does not require this dependency
* By dropping this dependency, we are no longer tying people to rails 4