### PR TITLE
OSEC-2817: Integrate backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,24 @@
+# For more information about the available options please visit: http://go/backstage (VPN required)
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    github.com/project-slug: Tapjoy/ldap_tools
+    snyk.io/org-id: cb8b78a9-d4c9-41fa-85e4-9a0b0026ee0d
+    snyk.io/target-id: Tapjoy/ldap_tools
+  name: ldap_tools
+  description: "Utilities to assist with the management of LDAP resources"
+  labels:
+    costcenter: "8213"
+  tags:
+    - public
+    - offerwall
+  links:
+    - url: https://unity.slack.com/channels/offerwall-eng-operations
+      title: "#offerwall-eng-operations"
+      icon: chat
+spec:
+  type: library
+  lifecycle: production
+  owner: tapjoy/eng-group-ops
+  system: offerwall-security


### PR DESCRIPTION

https://jira.unity3d.com/browse/OSEC-2817

In order to integrate with [Unity Backstage](https://backstage.corp.unity3d.com/), we are creating `catalog-info.yaml` files in all of our repositories.

> Unity Backstage is Unity's installation of the [Backstage](https://backstage.io/) open source project - a developer portal, service catalog and more

## How this impacts you

* Every repo will require a `catalog-info.yaml` which will be validated through PR workflows and auto-synchronized to Backstage

## What we use backstage for

* Integrates with SRE tooling, such as [OpsBot](https://docs.internal.unity.com/opsbot)
* Used as a source for defining team ownership
* [Component discovery](https://backstage.corp.unity3d.com/catalog?filters%5Bkind%5D=component&filters%5Buser%5D=all) for other developers
* [Documentation portal](https://backstage.corp.unity3d.com/docs?filters%5Buser%5D=all) for your repos (automatically built through source code)
* [Swagger UI](https://swagger.io/tools/swagger-ui/) for API docs ([example](https://backstage.corp.unity3d.com/catalog/default/api/ads-selfserve-dashboard-v2/definition#/))
* Can serve as a dashboard for tracking service dependencies, pagerduty alerts, etc.
* ...and more things you can explore yourself

## How to review

What we're primarily looking for out of this PR review:

* Ensure the `catalog-info.yaml` contains the correct metadata
* Ensure there are no syntax issues called out by github in the `catalog-info.yaml` file
